### PR TITLE
Update-READEME.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,13 +101,7 @@ Things you may want to cover:
 - has_many: likes
 - belongs_to:shipping_day
 
-## prefecturesテーブル
-|Column|Type|Options|
-|------|----|-------|
-|name|string|null:false|
 
-### Association
-has_many:products
 
 ## shipping_daysテーブル
 |Column|Type|Options|

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Things you may want to cover:
 |image|references|null:false,foreign_key:true|
 |like|references|foreign_key:true|
 |category|references|null:false,foreign_key:true|
-|prefecture|references|null:false,foreign_key:true|
+|prefecture_id(active_hash)|integer|null:false|
 |shipping_day|references|null:false,foreign_key:true|
 
 ### enum
@@ -99,7 +99,6 @@ Things you may want to cover:
 - has_many: images
 - has_many: commemts
 - has_many: likes
-- belongs_to:preficture
 - belongs_to:shipping_day
 
 ## prefecturesテーブル
@@ -122,8 +121,8 @@ has_many:products
 |Column|Type|Options|
 |------|----|-------|
 |user|references|null:false,foreign_key:true|
-|card-id|integer|null:false|
-|costomer_id|integer|null:false|
+|card_id|integer|null:false|
+|customer_id|integer|null:false|
 
 ### Association
 - belongs_to:user

--- a/README.md
+++ b/README.md
@@ -76,13 +76,9 @@ Things you may want to cover:
 |Column|Type|Options|
 |------|----|-------|
 |title|string|null:false|
-|brand|string|
 |description|text|null:false|
-|category|string|null:false|
 |condition|integer|null:false,default:0|
 |postage|integer|null:false|
-|shipping_origin|string|null:false|
-|days_until_shipping|string|null:false|
 |price|integer|null:false|
 |user|references|null:false,foreign_key:true|
 |comment|references| null:false,foreign_key:true|
@@ -90,6 +86,8 @@ Things you may want to cover:
 |image|references|null:false,foreign_key:true|
 |like|references|foreign_key:true|
 |category|references|null:false,foreign_key:true|
+|prefecture|references|null:false,foreign_key:true|
+|shipping_day|references|null:false,foreign_key:true|
 
 ### enum
 - enum condition:{新品/未使用:0,未使用に近い:1}
@@ -101,15 +99,31 @@ Things you may want to cover:
 - has_many: images
 - has_many: commemts
 - has_many: likes
+- belongs_to:preficture
+- belongs_to:shipping_day
+
+## prefecturesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null:false|
+
+### Association
+has_many:products
+
+## shipping_daysテーブル
+|Column|Type|Options|
+|------|----|-------|
+|day|string|null:false|
+
+### Association
+has_many:products
 
 ## credit_cardsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|card_number|integer|null:false,unique:true|
-|expiration_year|integer|null:false|
-|expiration_month|integer|null:false|
-|security_code|integer|null:false|
 |user|references|null:false,foreign_key:true|
+|card-id|integer|null:false|
+|costomer_id|integer|null:false|
 
 ### Association
 - belongs_to:user

--- a/README.md
+++ b/README.md
@@ -96,10 +96,10 @@ Things you may want to cover:
 - belongs_to: user
 - belongs_to: brand
 - belongs_to: category
-- has_many: images
-- has_many: commemts
-- has_many: likes
-- belongs_to:shipping_day
+- has_many: images,dependent::destroy
+- has_many: comments,dependent::destroy
+- has_many: likes,dependent::destroy
+- belongs_to: shipping_day
 
 
 


### PR DESCRIPTION
# what
スプリントレビュー時に、メンターの方からデータベースの設計で指摘された箇所を修正しました。
■credit-cardsテーブル
payjpというクレジットカード決済代行サービスを利用して、
カード情報そのものを登録しないように設計し直しました。
■shipping_daysテーブル、prefictures（県）テーブル
active_hashを用いた設計にし直しました。

# why
■credit-cardsテーブルの修正が必要な理由
DBに直接カード情報を登録する設計は法律違反かつ、セキュリティ上非常に危険だから

■shipping_daysテーブル、prefictures（県）テーブルの修正が必要な理由
都道府県など、変わりようがないデータは、データベースに保存しない設計にするのが望ましいから

# ER図
![ER図](https://user-images.githubusercontent.com/63944707/86593772-d112e280-bfd0-11ea-977e-1c15e8e2e80a.png)



