### PR TITLE
バリデーションの設定とバリデーションエラー時エラーメッセージを表示

### DIFF
--- a/app/assets/stylesheets/modules/_new_products.scss
+++ b/app/assets/stylesheets/modules/_new_products.scss
@@ -266,11 +266,11 @@
           right: 0;
           transform: translateY(-70%);
           text-align: right;
-        } 
-        .alert {
-          @extend %alert;
-        } 
+        }     
       }
+      .alert {
+        @extend %alert;
+      } 
     }
     .post-form {
       margin: 0 auto;

--- a/app/assets/stylesheets/modules/_new_products.scss
+++ b/app/assets/stylesheets/modules/_new_products.scss
@@ -23,43 +23,44 @@
     margin: 0 auto;
     max-width: 740px;
     
-  %basicSection {
-    font-size: 14px;
-    padding: 30px 50px 30px 50px;
-    color: rgb(168, 168, 168);
-    border-top: solid 1px rgb(168, 168, 168);
-  }
+    %basicSection {
+      font-size: 14px;
+      padding: 30px 50px 30px 50px;
+      color: rgb(168, 168, 168);
+      border-top: solid 1px rgb(168, 168, 168);
+    }
 
-  %inputName {
-    padding-top: 15px;
-    padding-bottom: 10px;
-    font-size: 15px;
-    color: #333;
-    span.require_label {
-      margin: 2px 5px;
-      align-items: center;
-      text-align: center;
-      width: 40px;
-      height: 13px;
-      font-size: 10px;
-      border-radius: 5px;
-      border: solid  red;
-      background-color: red;
-      color: white;   
-    }
-    span.optional_label {
-      margin: 2px 5px;
-      align-items: center;
-      text-align: center;
-      width: 40px;
-      height: 13px;
-      font-size: 10px;
-      border-radius: 5px;
-      color: white;  
-      border: solid  lightgrey;
-      background-color: lightgrey;
-    }
-  } 
+    %inputName {
+      padding-top: 15px;
+      padding-bottom: 10px;
+      font-size: 15px;
+      color: #333;
+      span.require_label {
+        display: inline;
+        margin: 2px 5px;
+        align-items: center;
+        text-align: center;
+        width: 40px;
+        height: 13px;
+        font-size: 10px;
+        border-radius: 5px;
+        border: solid  red;
+        background-color: red;
+        color: white;   
+      }
+      span.optional_label {
+        margin: 2px 5px;
+        align-items: center;
+        text-align: center;
+        width: 40px;
+        height: 13px;
+        font-size: 10px;
+        border-radius: 5px;
+        color: white;  
+        border: solid  lightgrey;
+        background-color: lightgrey;
+      }
+    } 
 
     %inputForm {
       width: 100%;
@@ -68,7 +69,16 @@
       padding-left: 10px;
       margin: 10px 0;
     }  
-    
+
+    %alert {
+      color: red; 
+      font-size: 15px;
+      ul {
+        padding: 0;
+        margin: 0;
+      }
+    }
+  
     .post-image-list {
       @extend %basicSection;
       padding-top: 20px;
@@ -111,7 +121,6 @@
                 cursor: pointer;
               }
             }
-            
           }
         }
         .image_input_btn {
@@ -144,6 +153,9 @@
             // display: none;
           } 
         }
+        .alert {
+          @extend %alert;
+        }
       }
     }
     .product-information {
@@ -153,6 +165,9 @@
         &--text_form {
           @extend %inputForm;
         }
+        .alert {
+          @extend %alert;
+        }
       }
       &__description {
         @extend %inputName;
@@ -160,11 +175,17 @@
           @extend %inputForm;
           height: 200px;
         }
+        .alert {
+          @extend %alert;
+        }
       }
       &__category {
         @extend %inputName;
         &--select_form {
           @extend %inputForm;
+        }
+        .alert {
+          @extend %alert;
         }
         &--size {
         @extend %inputName;
@@ -189,6 +210,9 @@
         &--select_form {
           @extend %inputForm;  
         }
+        .alert {
+          @extend %alert;
+        }
       }
     }
     .delivery-information {
@@ -198,17 +222,26 @@
         &--select_form {
           @extend %inputForm;
         }
+        .alert {
+          @extend %alert;
+        }
       }
       &__prefecture {
         @extend %inputName;
         &--select_form {
           @extend %inputForm;
         }
+        .alert {
+          @extend %alert;
+        }
       }
       &__shipping_day {
         @extend %inputName;
         &--select_form {
           @extend %inputForm;
+        }
+        .alert {
+          @extend %alert;
         }
       }
     }
@@ -233,7 +266,10 @@
           right: 0;
           transform: translateY(-70%);
           text-align: right;
-          }  
+        } 
+        .alert {
+          @extend %alert;
+        } 
       }
     }
     .post-form {

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,6 @@
 class ProductsController < ApplicationController
 
-  # before_action :set_category, only: [:new, :edit, :create, :update, :destroy]
+  before_action :set_category, only: [:new, :edit, :create, :update, :destroy]
 
   def index
     @products = Product.includes(:images).order('created_at DESC')
@@ -23,23 +23,25 @@ class ProductsController < ApplicationController
     #選択された親カテゴリーに紐付く子カテゴリーの配列を取得
     @category_children = Category.find(params[:parent_name]).children
   end
+
   #子カテゴリーが選択された後に動くアクション
   def get_category_grandchildren
     #選択された子カテゴリーに紐付く孫カテゴリーの配列を取得
     @category_grandchildren = Category.find("#{params[:child_id]}").children
   end
-  
-  def new_product_create
-  end
 
   def create
+    @brands = Brand.all
     @category_parent_array = Category.where(ancestry: nil)
     @product = Product.new(product_params)
     if @product.save
       redirect_to new_product_create_products_path
     else
-      render :new
+      render :new and return
     end
+  end
+
+  def new_product_create
   end
 
   def edit

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -1,4 +1,5 @@
 class TopController < ApplicationController
   def index
+    @products = Product.includes(:images).order('created_at DESC')
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -2,7 +2,7 @@ class Product < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
   has_many :images, dependent: :destroy
   belongs_to :category 
-  belongs_to :brand
+  belongs_to :brand, optional: true
   belongs_to :user
   belongs_to_active_hash :prefecture
   belongs_to_active_hash :shipping_day
@@ -20,7 +20,7 @@ class Product < ApplicationRecord
             :shipping_day_id, 
             :price,
             :user_id, 
-             presence: true
+            presence: true
 
   enum condition: { 
     brand_new: 1,               # "新品・未使用"

--- a/app/views/products/_form.html.haml
+++ b/app/views/products/_form.html.haml
@@ -7,13 +7,13 @@
       %p.post-image-list__explanation 最大5枚までアップロードできます
       #image-box.post-image-list__box  
         #previews.preview_list
-          -if @product.persisted?
-            .preview_image_box
-              -@product.images.each_with_index do |image, i|
-                =image_tag image.src.url, data: { index: i }, width: "120", height: '120', class: "preview_image"
-                .edit_box
-                  %label.edit_btn 編集
-                  %span#delete_btn.js-remove 削除 
+        -#   -if @product.persisted?
+        -#     .preview_image_box
+        -#       -@product.images.each_with_index do |image, i|
+        -#         =image_tag image.src.url, data: { index: i }, width: "120", height: '120', class: "preview_image"
+        -#         .edit_box
+        -#           %label.edit_btn 編集
+        -#           %span#delete_btn.js-remove 削除 
         %label{for: "product_images_attributes_0_src", class: "image_input_btn", id: "image_input_btn--0"} 
           #posts.post_form
             =image_tag('icon_camera.png', class: "image_input_btn_camera")
@@ -112,15 +112,15 @@
     .price-information
       価格
       .price-information__price
-        %price 販売価格
+        %label 販売価格
         %span.require_label 必須
         %span.en ￥
         = f.number_field :price, class: "price_form", min: 300, max:9999999, placeholder: "0"
-        -if @product.errors.any? 
-          .alert
-            %ul
-              -@product.errors.full_messages_for(:price).each do |error| 
-                %li= error
+      -if @product.errors.any? 
+        .alert
+          %ul
+            -@product.errors.full_messages_for(:price).each do |error| 
+              %li= error
     .post-form
       = f.submit "出品する", class: "submit_btn"
       = link_to "もどる", root_path, class: "return_btn"

--- a/app/views/products/_form.html.haml
+++ b/app/views/products/_form.html.haml
@@ -2,19 +2,18 @@
   = form_with model: @product do |f|
     .post-image-list
       .post-image-list__title
-        = f.label  '出品画像' 
+        %label 出品画像
         %span.require_label 必須
       %p.post-image-list__explanation 最大5枚までアップロードできます
       #image-box.post-image-list__box  
         #previews.preview_list
-          -# 編集機能時に画像を表示
-          -# -if @product.persisted?
-          -#   .preview_image_box
-          -#     -@product.images.each_with_index do |image, i|
-          -#       =image_tag image.src.url, data: { index: i }, width: "120", height: '120', class: "preview_image"
-          -#       .edit_box
-          -#         %label.edit_btn 編集
-          -#         %span#delete_btn.js-remove 削除 
+          -if @product.persisted?
+            .preview_image_box
+              -@product.images.each_with_index do |image, i|
+                =image_tag image.src.url, data: { index: i }, width: "120", height: '120', class: "preview_image"
+                .edit_box
+                  %label.edit_btn 編集
+                  %span#delete_btn.js-remove 削除 
         %label{for: "product_images_attributes_0_src", class: "image_input_btn", id: "image_input_btn--0"} 
           #posts.post_form
             =image_tag('icon_camera.png', class: "image_input_btn_camera")
@@ -33,50 +32,95 @@
           -# -if @product.persisted?
           -#   %div{ data: {index: "<%= @product.images.count %>" }, class: "hidden_post_form_#{@product.images.count}" }
           -#     =file_field_tag :src, name: "product[images_attributes][#{@product.images.count}][src]", class: 'hidden_field'
+        -if @product.errors.any? 
+          .alert
+            %ul
+              -@product.errors.full_messages_for(:images).each do |error| 
+                %li= error
     .product-information
       商品の詳細
       .product-information__title
-        = f.label :title, '商品名' 
+        %label 商品名 
         %span.require_label 必須
         = f.text_field :title, { class: "product-information__title--text_form", maxlength: 40, placeholder: "40文字まで" }
+        -if @product.errors.any? 
+          .alert
+            %ul
+              -@product.errors.full_messages_for(:title).each do |error| 
+                %li= error
       .product-information__description
-        = f.label :description, '商品の説明'
+        %label 商品の説明
         %span.require_label 必須
         = f.text_area :description, { class: "product-information__description--text_area_form", placeholder: "" }
+        -if @product.errors.any? 
+          .alert
+            %ul
+              -@product.errors.full_messages_for(:description).each do |error| 
+                %li= error
       .product-information__category
-        = f.label :category_id, 'カテゴリー', class: "production-information__category-label"
+        %label カテゴリー
         %span.require_label 必須
         .product-information__category--form
           = f.select :category_id, options_for_select(@category_parent_array.map{|c| [c[:name], c[:id]]}), {include_blank: "選択してください"}, { class: "product-information__category--select_form", id: "parent_category"}
+        -if @product.errors.any? 
+          .alert
+            %ul
+              -@product.errors.full_messages_for(:category_id).each do |error| 
+                %li= error
       .product-information__brand
-        = f.label :brand, 'ブランド' 
+        %label ブランド 
         %span.optional_label 任意
-        = f.select :brand_id,options_for_select(@brands.map{|c| [c[:brand_name], c[:id]]}), {include_blank: "例：グッチ"}, { class: "product-information__brand--select_form"}
+        = f.collection_select :brand_id, Brand.all, :id, :brand_name, {include_blank: "例：グッチ"}, { class: "product-information__brand--select_form"}
       .product-information__condition
-        = f.label :condition, '商品の状態' 
+        %label 商品の状態 
         %span.require_label 必須
         = f.select :condition, Product.conditions_i18n.invert, { prompt: "選択してください" }, { class: "product-information__condition--select_form"}
+        -if @product.errors.any? 
+          .alert
+            %ul
+              -@product.errors.full_messages_for(:condition).each do |error| 
+                %li= error
     .delivery-information 
       配送について
       .delivery-information__postage
-        = f.label :postage, '配送料の負担' 
+        %label 配送料の負担
         %span.require_label 必須
         = f.select :postage, Product.postages_i18n.invert, { prompt: "選択してください" }, { class: "delivery-information__postage--select_form"}
+        -if @product.errors.any? 
+          .alert
+            %ul
+              -@product.errors.full_messages_for(:postage).each do |error| 
+                %li= error
       .delivery-information__prefecture
-        = f.label :prefecture_id, '発送元の地域' 
+        %label 発送元の地域
         %span.require_label 必須
         = f.collection_select :prefecture_id, Prefecture.all, :id, :name, { prompt: "選択してください" }, { class: "delivery-information__prefecture--select_form" }
+        -if @product.errors.any? 
+          .alert
+            %ul
+              -@product.errors.full_messages_for(:prefecture_id).each do |error| 
+                %li= error
       .delivery-information__shipping_day
-        = f.label :shipping_day_id, '発送までの日数' 
+        %shipping_day_id 発送までの日数 
         %span.require_label 必須
         = f.collection_select :shipping_day_id, ShippingDay.all, :id, :name, { prompt: "選択してください" }, {class: "delivery-information__shipping_day--select_form" }
+        -if @product.errors.any? 
+          .alert
+            %ul
+              -@product.errors.full_messages_for(:shipping_day_id).each do |error| 
+                %li= error
     .price-information
       価格
       .price-information__price
-        = f.label :price, '販売価格' 
+        %price 販売価格
         %span.require_label 必須
         %span.en ￥
         = f.number_field :price, class: "price_form", min: 300, max:9999999, placeholder: "0"
+        -if @product.errors.any? 
+          .alert
+            %ul
+              -@product.errors.full_messages_for(:price).each do |error| 
+                %li= error
     .post-form
       = f.submit "出品する", class: "submit_btn"
       = link_to "もどる", root_path, class: "return_btn"

--- a/app/views/products/_product.html.haml
+++ b/app/views/products/_product.html.haml
@@ -5,7 +5,7 @@
   %p= product.description
   %p= product.condition_i18n  
   %p= product.category.name
-  %p= product.brand.brand_name
+  %p= product.brand_id
   %p= product.postage_i18n      #enum_helpを用いた記述
   %p= product.prefecture.name
   %p= product.shipping_day.name

--- a/app/views/top/index.html.haml
+++ b/app/views/top/index.html.haml
@@ -9,3 +9,4 @@
   %h2 ログインしていません
   = link_to "新規登録", new_user_registration_path
   = link_to "ログイン", new_user_session_path
+  

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,5 +1,18 @@
 ja:
   activerecord:
+    models:
+      product:
+    attributes:
+      product:
+        images: '出品画像'
+        title: '商品名'
+        description: '商品の説明'
+        category_id: 'カテゴリー'
+        condition: '商品の状態'
+        postage: '配送料の負担'
+        prefecture_id: '発送元の地域'
+        shipping_day_id: '発送までの日数'
+        price: '販売価格'
   enums:
     product:
       condition:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,6 @@ Rails.application.routes.draw do
       get 'new_product_create'
     end
   end
-
+  resources :top, only: [:index]
   root to: "top#index"
 end

--- a/db/migrate/20200719152035_add_foreign_keyd_brand_id_to_products.rb
+++ b/db/migrate/20200719152035_add_foreign_keyd_brand_id_to_products.rb
@@ -1,5 +1,7 @@
 class AddForeignKeydBrandIdToProducts < ActiveRecord::Migration[5.2]
   def change
     add_reference :products, :brand, foreign_key: true
+    add_reference :products, :
+    add_reference :products,
   end
 end


### PR DESCRIPTION
# What
必須の入力欄（images、title、description、category_id、condition、postag、eprefectrue_id、shipping_id、price）が空の時は出品できないようにバリデーションを設定した。
また、任意の入力欄（brand_id）が空の時は出品できるようにバリデーションを設定した。

バリデーションのエラーが出たときはそれぞれの入力フォーム下にエラーメッセージを表示されるように設定した。
<img width="766" alt="バリデーションエラー日本語メッセージ" src="https://user-images.githubusercontent.com/63962501/88243027-0f471c00-ccca-11ea-955f-c60660ff09d5.png">

#Why
商品を出品する際必須の項目は必ず入力された状態で保存させるため。