### PR TITLE
Feature/issue13

### DIFF
--- a/db/migrate/20200806005640_add_buyer_id_to_products.rb
+++ b/db/migrate/20200806005640_add_buyer_id_to_products.rb
@@ -1,0 +1,5 @@
+class AddBuyerIdToProducts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :Products, :buyer_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_25_220208) do
+ActiveRecord::Schema.define(version: 2020_08_06_005640) do
 
   create_table "brands", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "brand_name"
@@ -83,6 +83,7 @@ ActiveRecord::Schema.define(version: 2020_07_25_220208) do
     t.bigint "brand_id"
     t.bigint "category_id", null: false
     t.bigint "size_id"
+    t.integer "buyer_id"
     t.index ["brand_id"], name: "index_products_on_brand_id"
     t.index ["category_id"], name: "index_products_on_category_id"
     t.index ["size_id"], name: "index_products_on_size_id"


### PR DESCRIPTION
# What
productsテーブルへbuyer_idカラムを追加した。

# Why
・商品が購入されたとき、誰が購入したか分からないため追加した。
・この購入者のidをカラムに追記することで、
　商品にbuyer_idが存在していれば、その商品をsoldとみなすことができて、かつ、
　商品上にsoldという表示を付与することができるようになるため。

## add column後のターミナル、SequelPro、VSコードの画像
https://gyazo.com/658c445484b8568a185c613433ca90a0