### PR TITLE
購入後の商品は買えないようにする実装

### DIFF
--- a/app/assets/stylesheets/modules/_buy_products.scss
+++ b/app/assets/stylesheets/modules/_buy_products.scss
@@ -98,13 +98,17 @@
       }
       .purchase {
         margin: 16px 0 0;
-         background: #888888;
+         background: #3ccace;
          color: #fff;
          display: block;
          width: 100%;
          line-height: 48px;
          font-size: 14px;
-         border-radius: 4px;
+         border-radius: 100px;
+         cursor: pointer;
+         text-decoration: none;
+         border: solid;
+         font-size: 18px;
       }
     }
 

--- a/app/assets/stylesheets/modules/_index_products.scss
+++ b/app/assets/stylesheets/modules/_index_products.scss
@@ -4,10 +4,8 @@
     position: absolute;
     color: #fff;
     background-color:#ea352d;
-    }
   }
-
-  
+} 
 .discription{
   padding: 16px;
   .products-index-title{

--- a/app/assets/stylesheets/modules/_purchased_products.scss
+++ b/app/assets/stylesheets/modules/_purchased_products.scss
@@ -16,13 +16,14 @@
       }
     }  
     .logaut_content {
-      background-color:red;
+      background-color:#3ccace;
       padding: 10px;
       .btn-default{
         color: white;
         text-decoration: none;
         line-height: 30px;
         cursor: pointer;
+        font-size: 18px;
       }
     } 
   }

--- a/app/assets/stylesheets/modules/_show_products.scss
+++ b/app/assets/stylesheets/modules/_show_products.scss
@@ -3,6 +3,7 @@
   margin: 0 auto;
   background-color: #f8f8f8;
   height: 650vh;
+  width: 100vw;
 }
 
 //productBox
@@ -101,6 +102,25 @@
     height: 40px;
     margin-top: 15px;
   }
+  &__sold {
+    text-align: center;
+    margin: 16px 0 0;
+    background: #888888;
+    width: 100%;
+    border-radius: 100px;
+    .disabled-button {
+      color: #fff;
+      border-radius: 100px;
+      font-size: 24px;
+      text-decoration: none;
+      display: block;
+      cursor: not-allowed;
+      background: #888888;
+      width: 100%;
+      border: solid;
+    }
+
+  }
   &__toBuy {
     text-align: center;
     line-height: 48px;
@@ -159,6 +179,7 @@ ul {
       height: 346px;
       
     }
+    // 購入されたら画像にsoldと表示される
     .items-box_photo__sold{
       display: block;
       

--- a/app/assets/stylesheets/modules/_show_products.scss
+++ b/app/assets/stylesheets/modules/_show_products.scss
@@ -3,7 +3,7 @@
   margin: 0 auto;
   background-color: #f8f8f8;
   width: 100vw;
-  height: 650vh;
+  height: 350vh;
 }
 
 //productBox

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -10,7 +10,7 @@
         %ul.images
           %li.images__list
             = image_tag @images[0].src.url, class: "images__list--main"
-              //buyer_idがある場合には、SOLDと表示させる
+              -# buyer_idがある場合には、SOLDと表示させる
               -if @product.buyer_id.present? 
               .items-box_photo__sold
                 .items-box_photo__sold__inner SOLD
@@ -90,10 +90,13 @@
           = link_to product_path(@product),class: "productBox__edit--btn", method: :delete, data: { confirm: "本当に削除しますか？" } do
             %i.fa.fa-trash
             削除する
-
+        -#「購入する」リンクを「売り切れました」ボタンに変える     
+      - elsif @product.buyer_id.present?
+        .productBox__sold 
+          %button.disabled-button 売り切れました
       - else
         .productBox__toBuy
-          = link_to "購入する", product_path, class:"productBox__toBuy--buy"
+          = link_to "購入する", buy_product_path, class:"productBox__toBuy--buy"
 
 
     -# コメント欄

--- a/app/views/top/index.html.haml
+++ b/app/views/top/index.html.haml
@@ -10,3 +10,6 @@
   %h2 ログインしていません
   = link_to "新規登録", new_user_registration_path
   = link_to "ログイン", new_user_session_path
+.body
+  新規アイテム
+  = render @products


### PR DESCRIPTION
# What
・購入後、商品の詳細ページに飛ぶと「購入する」ボタンが「売り切れました」に変わる
・クリックしても購入ページに遷移しない

# Why
一度購入した商品が何度も購入できるような事態を防ぐため必要な機能

### 一連の流れの動画
・詳細ページから購入完了まで
https://gyazo.com/a76f6f61c486bcaee16a3ff333364da8

・購入した商品は買えない
https://gyazo.com/7711b55751e6646f9fc0bccf10517ba5