### PR TITLE
productsテーブルのuser_id＝ログイン中のuser_idだとbuyアクションが動かない実装

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -3,6 +3,7 @@ class ProductsController < ApplicationController
   before_action :set_category, only: [:new, :edit, :create, :update, :destroy]
   before_action :move_to_root, except: :show
   before_action :set_product, only: [:edit, :update, :show, :destroy, :buy, :purchase]
+  before_action :not_buy_product, only: :buy
 
 
   def index
@@ -130,6 +131,8 @@ class ProductsController < ApplicationController
       end
     end
 
+   
+
     def purchase
       @creditcard = CreditCard.find_by(user_id: current_user.id)
      
@@ -181,6 +184,13 @@ class ProductsController < ApplicationController
   # 投稿者だけが編集ページに遷移できるようにする
   def not_productuser
     if current_user.id != @product.user_id
+      redirect_to root_path
+    end
+  end
+
+  # ログイン中のユーザーと、商品のユーザーidが同じであればトップ画面に戻る
+  def not_buy_product
+    if current_user.id == @product.user_id
       redirect_to root_path
     end
   end


### PR DESCRIPTION
## What
出品した商品に紐づくuser_id＝ログイン中のuser_idの場合、buyアクションが動かないようにしました。
before_actionで阻止しました。

## Why
URLに```http://localhost:3000/products/3/buy```と入力すると、products_idが３の商品を出品したユーザー自身が、
その出品した商品を買えてしまうため、阻止する必要がある。

### 同一ユーザーが購入確認前のページに進もうとするとトップに戻る動画
https://gyazo.com/2f38066d4e4811d31ad5e991d401e7f0