### PR TITLE
商品出品機能　バリデーションエラー時入力フォームに戻った際の挙動修正

### DIFF
--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -15,7 +15,7 @@ $(function() {
   function appendChildrenBox(insertHTML){
     var childSelectHtml =  '';
     childSelectHtml = `<div class="product-information__category--form" id= "children_form">
-                        <select class="product-information__category--select_form" id="child_category">
+                        <select class="product-information__category--select_form" id="child_category" name="product[category_id]">
                           <option value="" data-category="" >選択してください</option>
                           ${insertHTML}
                         </select>

--- a/app/assets/javascripts/products.js
+++ b/app/assets/javascripts/products.js
@@ -29,7 +29,22 @@ $(function() {
     }
   }
   //
-  
+
+  //バリデーションエラーで入力欄に戻った時
+  if (window.location.href.match(/\/(products)$/)) {
+    //投稿済み画像のプレビュー表示欄の要素を取得する
+    var prevContent = $('.image_input_btn').prev();
+    labelWidth = (640 - $(prevContent).css('width').replace(/[^0-9]/g, ''));
+    $('.image_input_btn').css('width', labelWidth);
+    //プレビューの要素数を取得
+    var count = $('.preview_image_box').length;
+    //プレビューが５つあるときは、投稿ボックスを消しておく
+    if (count == 5) {
+      $('.image_input_btn').hide();
+    }
+  }
+  //
+
   // image_input_btnのwidth操作
   function setLabel() {
     // プレビューボックスのwidthを取得し、maxから引くことでimage_input_btnのwidthを決定

--- a/app/assets/javascripts/products.js
+++ b/app/assets/javascripts/products.js
@@ -29,22 +29,7 @@ $(function() {
     }
   }
   //
-
-  //バリデーションエラーで入力欄に戻った時
-  if (window.location.href.match(/\/(products)$/)) {
-    //投稿済み画像のプレビュー表示欄の要素を取得する
-    var prevContent = $('.image_input_btn').prev();
-    labelWidth = (640 - $(prevContent).css('width').replace(/[^0-9]/g, ''));
-    $('.image_input_btn').css('width', labelWidth);
-    //プレビューの要素数を取得
-    var count = $('.preview_image_box').length;
-    //プレビューが５つあるときは、投稿ボックスを消しておく
-    if (count == 5) {
-      $('.image_input_btn').hide();
-    }
-  }
-  //
-
+  
   // image_input_btnのwidth操作
   function setLabel() {
     // プレビューボックスのwidthを取得し、maxから引くことでimage_input_btnのwidthを決定

--- a/app/assets/stylesheets/modules/_edit_products.scss
+++ b/app/assets/stylesheets/modules/_edit_products.scss
@@ -109,6 +109,7 @@
           .preview_image_box {
             margin-right: 5px;
             .preview_image {
+              width: 120px;
             }
             .update_box {
               background-color:  #eee;

--- a/app/assets/stylesheets/modules/_new_products.scss
+++ b/app/assets/stylesheets/modules/_new_products.scss
@@ -103,6 +103,7 @@
           .preview_image_box {
             margin-right: 5px;
             .preview_image {
+              width: 120px;
             }
             .update_box {
               background-color:  #eee;

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -43,7 +43,7 @@ class ProductsController < ApplicationController
       end
   end
 
-  def create
+  def create   
     @brands = Brand.all
     @category_parent_array = Category.where(ancestry: nil)
     @sizes = Size.where(ancestry: nil)
@@ -78,6 +78,7 @@ class ProductsController < ApplicationController
   end
 
   def update
+    @sizes = Size.where(ancestry: nil)
     if @product.update(product_params)
       redirect_to product_path(@product.id)
     else
@@ -150,7 +151,7 @@ class ProductsController < ApplicationController
                            :prefecture_id, 
                            :shipping_day_id, 
                            :price, 
-                           images_attributes: [:src, :_destroy, :id])
+                           images_attributes: [:src, :_destroy, :id, :src_cache])
                            .merge(user_id: current_user.id)
   end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -44,14 +44,14 @@ class ProductsController < ApplicationController
   end
 
   def create   
+    @brands = Brand.all
+    @category_parent_array = Category.where(ancestry: nil)
     @sizes = Size.where(ancestry: nil)
     @product = Product.new(product_params)
     if @product.save
       redirect_to new_product_create_product_path(@product.id)
     else
-      if @product.category_id.present?
-        set_sizes
-      end
+      set_sizes
       render action: :new, locals: { product: @product }
     end
   end
@@ -65,11 +65,10 @@ class ProductsController < ApplicationController
     @category_parent_array = Category.where(ancestry: nil)
     @category_children = @product.category.parent.parent.children
     @category_grandchildren = @product.category.parent.children
-    @sizes = Size.where(ancestry: nil)
+    # サイズを取得するメソッド
     set_sizes
   end
 
-  # サイズを取得するメソッド
   def set_sizes
     @category_id = @product.category_id
     selected_grandchild =Category.find(@category_id)
@@ -83,37 +82,13 @@ class ProductsController < ApplicationController
     end
   end
 
-  def size_exist
-    @category_id = @product.category_id
-    if @product.category_id.present?
-      selected_grandchild =Category.find(@category_id)
-      if related_size_parent = selected_grandchild.sizes[0]
-        @sizes = related_size_parent.children
-        @sizes.exists?
-      elsif
-        selected_child =Category.find(@category_id).parent
-        if related_size_parent = selected_child.sizes[0]
-          @sizes = related_size_parent.children
-          @sizes.exists?
-        end
-      else
-      end
-    end
-  end
-
-  helper_method :size_exist
+  helper_method :set_sizes
 
   def update
     @sizes = Size.where(ancestry: nil)
     if @product.update(product_params)
-      if @product.size.nil?
-        @product.size.update == nil
-      end
       redirect_to product_path(@product.id)
     else
-      if @product.category_id.present?
-        set_sizes
-      end
       render :edit
     end
   end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -49,4 +49,9 @@ class ImageUploader < CarrierWave::Uploader::Base
   # def filename
   #   "something.jpg" if original_filename
   # end
+
+  # cacheでアップロードする画像の設定
+  def cache_dir
+    "uploads/cache/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
 end

--- a/app/views/products/_edit_form.html.haml
+++ b/app/views/products/_edit_form.html.haml
@@ -63,20 +63,20 @@
         .product-information__category--form
           = f.select :category_id, options_for_select(@category_parent_array.map{|c| [c[:name], c[:id], {'data-category'=>c[:id]}]}, @product.category.parent.parent.id), {}, { class: "product-information__category--select_form", id: "parent_category"}
           #children_form.product-information__category--form
-            = f.select :category_id, options_for_select(@category_children.map{|c| [c[:name], c[:id], {'data-category'=>c[:id]}]}, @product.category.parent.id), {}, { class: "product-information__category--select_form", id: "child_category"}
+            = f.select :category_id, options_for_select(@product.category.parent.parent.children.map{|c| [c[:name], c[:id], {'data-category'=>c[:id]}]}, @product.category.parent.id), {}, { class: "product-information__category--select_form", id: "child_category"}
           #grandchildren_form.product-information__category--form
-            = f.select :category_id, options_for_select(@category_grandchildren.map{|c| [c[:name], c[:id],{'data-category'=>c[:id]}]}, @product.category.id), {}, { class: "product-information__category--select_form", id: "grandchild_category"}
+            = f.select :category_id, options_for_select(@product.category.parent.children.map{|c| [c[:name], c[:id],{'data-category'=>c[:id]}]}, @product.category.id), {}, { class: "product-information__category--select_form", id: "grandchild_category"}
         -if @product.errors.any? 
           .alert
             %ul
               -@product.errors.full_messages_for(:category_id).each do |error| 
                 %li= error
       #size_wrapper.product-information__size
-        -if @sizes.present?
+        -if size_exist
           %label.product-information__label サイズ
           %span.require_label 必須
           #size_form.product-information__size--form
-            = f.collection_select :size_id, @sizes, :id, :size, {}, { class: "product-information__size--select_form", id: "size"}
+            = f.collection_select :size_id, @sizes, :id, :size, {include_blank: "選択してください"}, { class: "product-information__size--select_form", id: "size"}
         -if @product.errors.any? 
           .alert
             %ul

--- a/app/views/products/_edit_form.html.haml
+++ b/app/views/products/_edit_form.html.haml
@@ -29,6 +29,7 @@
               -# プレビューが出ている分のfile_fieldとdelete用のチェックボックスを設置
               = i.file_field :src, class: "hidden-field"
               = i.check_box :_destroy, class: "hidden-checkbox"
+              = i.hidden_field :src_cache
             -@product.images.length.upto(4) do |i|
               %input{class: "hidden-field", type: "file", name: "product[images_attributes][#{i}][src]", id: "product_images_attributes_#{i}_src"}
         -if @product.errors.any? 

--- a/app/views/products/_edit_form.html.haml
+++ b/app/views/products/_edit_form.html.haml
@@ -63,20 +63,20 @@
         .product-information__category--form
           = f.select :category_id, options_for_select(@category_parent_array.map{|c| [c[:name], c[:id], {'data-category'=>c[:id]}]}, @product.category.parent.parent.id), {}, { class: "product-information__category--select_form", id: "parent_category"}
           #children_form.product-information__category--form
-            = f.select :category_id, options_for_select(@product.category.parent.parent.children.map{|c| [c[:name], c[:id], {'data-category'=>c[:id]}]}, @product.category.parent.id), {}, { class: "product-information__category--select_form", id: "child_category"}
+            = f.select :category_id, options_for_select(@category_children.map{|c| [c[:name], c[:id], {'data-category'=>c[:id]}]}, @product.category.parent.id), {}, { class: "product-information__category--select_form", id: "child_category"}
           #grandchildren_form.product-information__category--form
-            = f.select :category_id, options_for_select(@product.category.parent.children.map{|c| [c[:name], c[:id],{'data-category'=>c[:id]}]}, @product.category.id), {}, { class: "product-information__category--select_form", id: "grandchild_category"}
+            = f.select :category_id, options_for_select(@category_grandchildren.map{|c| [c[:name], c[:id],{'data-category'=>c[:id]}]}, @product.category.id), {}, { class: "product-information__category--select_form", id: "grandchild_category"}
         -if @product.errors.any? 
           .alert
             %ul
               -@product.errors.full_messages_for(:category_id).each do |error| 
                 %li= error
       #size_wrapper.product-information__size
-        -if size_exist
+        -if @sizes.present?
           %label.product-information__label サイズ
           %span.require_label 必須
           #size_form.product-information__size--form
-            = f.collection_select :size_id, @sizes, :id, :size, {include_blank: "選択してください"}, { class: "product-information__size--select_form", id: "size"}
+            = f.collection_select :size_id, @sizes, :id, :size, {}, { class: "product-information__size--select_form", id: "size"}
         -if @product.errors.any? 
           .alert
             %ul

--- a/app/views/products/_new_form.html.haml
+++ b/app/views/products/_new_form.html.haml
@@ -61,21 +61,21 @@
         %label カテゴリー
         %span.require_label 必須
         .product-information__category--form
-          -if @product.category_id.present?
+          -if @product.category_id.blank?
+            = f.select :category_id, options_for_select(@category_parent_array.map{|c| [c[:name], c[:id], {'data-category'=>c[:id]}]}, ), {include_blank: "選択してください"}, { class: "product-information__category--select_form", id: "parent_category"} 
+          -else
             = f.select :category_id, options_for_select(@category_parent_array.map{|c| [c[:name], c[:id], {'data-category'=>c[:id]}]}, @product.category.parent.parent.id), {}, { class: "product-information__category--select_form", id: "parent_category"}
             #children_form.product-information__category--form
               = f.select :category_id, options_for_select(@product.category.parent.parent.children.map{|c| [c[:name], c[:id], {'data-category'=>c[:id]}]}, @product.category.parent.id), {}, { class: "product-information__category--select_form", id: "child_category"}
             #grandchildren_form.product-information__category--form
               = f.select :category_id, options_for_select(@product.category.parent.children.map{|c| [c[:name], c[:id],{'data-category'=>c[:id]}]}, @product.category.id), {}, { class: "product-information__category--select_form", id: "grandchild_category"}
-          -else
-            = f.select :category_id, options_for_select(@category_parent_array.map{|c| [c[:name], c[:id], {'data-category'=>c[:id]}]}, ), {include_blank: "選択してください"}, { class: "product-information__category--select_form", id: "parent_category"} 
         -if @product.errors.any? 
           .alert
             %ul
               -@product.errors.full_messages_for(:category_id).each do |error| 
                 %li= error
       #size_wrapper.product-information__size
-        -if size_exist
+        -if @sizes.present?
           %label.product-information__label サイズ
           %span.require_label 必須
           #size_form.product-information__size--form

--- a/app/views/products/_new_form.html.haml
+++ b/app/views/products/_new_form.html.haml
@@ -5,21 +5,33 @@
         %label 出品画像
         %span.require_label 必須
       %p.post-image-list__explanation 最大5枚までアップロードできます
-      #image-box.post-image-list__box  
+      #image-box.post-image-list__box
         #previews.preview_list
-
+          -# cacheに値がセットされている場合は画像を表示
+          -if @product.images[0].src.url.present?
+            -@product.images.each_with_index do |image, i|
+              .preview_image_box{id: "preview_image_box__#{i}"}
+                .upper-box
+                  =image_tag image.src.url, alt:"preview", width: "120", height: '120', class: "preview_image", id: "preview_image"
+                .update_box
+                  .js-remove{id: "delete_btn_#{i}"}
+                    %span 削除
+              -# =image_tag @product.images[0].src.url if @product.images[0].src.url.present?
         %label{for: "product_images_attributes_0_src", class: "image_input_btn", id: "image_input_btn--0"} 
           #posts.post_form
             =image_tag('icon_camera.png', class: "image_input_btn_camera")
             .image_input_btn_text クリックしてファイルをアップロード
         .hidden_post_form
           =f.fields_for :images do |image|
+            
             -# 画像がビルドされた際に振られるidを取得
             =image.file_field :src, class:"hidden-field" 
             =image.file_field :src, class:"hidden-field", name: "product[images_attributes][1][src]", id: "product_images_attributes_1_src"
             =image.file_field :src, class:"hidden-field", name: "product[images_attributes][2][src]", id: "product_images_attributes_2_src"
             =image.file_field :src, class:"hidden-field", name: "product[images_attributes][3][src]", id: "product_images_attributes_3_src"
             =image.file_field :src, class:"hidden-field", name: "product[images_attributes][4][src]", id: "product_images_attributes_4_src"
+            -# cacheを使用するためにhidden_fieldを設置
+            =image.hidden_field :src_cache
         -if @product.errors.any? 
           .alert
             %ul
@@ -49,7 +61,24 @@
         %label カテゴリー
         %span.require_label 必須
         .product-information__category--form
-          = f.select :category_id, options_for_select(@category_parent_array.map{|c| [c[:name], c[:id]]}), {include_blank: "選択してください"}, { class: "product-information__category--select_form", id: "parent_category"}
+          -if @product.category.parent.parent.id.exists?
+            = f.select :category_id, options_for_select(@category_parent_array.map{|c| [c[:name], c[:id], {'data-category'=>c[:id]}]}, @product.category.parent.parent.id), {include_blank: "選択してください"}, { class: "product-information__category--select_form", id: "parent_category"}
+              #children_form.product-information__category--form
+                = f.select :category_id, options_for_select(@category_children.map{|c| [c[:name], c[:id], {'data-category'=>c[:id]}]}, @product.category.parent.id), {include_blank: "選択してください"}, { class: "product-information__category--select_form", id: "child_category"}
+              #grandchildren_form.product-information__category--form
+                = f.select :category_id, options_for_select(@category_grandchildren.map{|c| [c[:name], c[:id],{'data-category'=>c[:id]}]}, @product.category.id), {include_blank: "選択してください"}, { class: "product-information__category--select_form", id: "grandchild_category"}
+          -elsif @product.category.parent.id.exists?
+            = f.select :category_id, options_for_select(@category_parent_array.map{|c| [c[:name], c[:id], {'data-category'=>c[:id]}]}, @product.category.parent.id), {include_blank: "選択してください"}, { class: "product-information__category--select_form", id: "parent_category"}
+              #children_form.product-information__category--form
+                = f.select :category_id, options_for_select(@category_children.map{|c| [c[:name], c[:id], {'data-category'=>c[:id]}]}, @product.category.id), {include_blank: "選択してください"}, { class: "product-information__category--select_form", id: "child_category"}
+              #grandchildren_form.product-information__category--form
+                = f.select :category_id, options_for_select(@category_grandchildren.map{|c| [c[:name], c[:id],{'data-category'=>c[:id]}]}), {include_blank: "選択してください"}, { class: "product-information__category--select_form", id: "grandchild_category"}
+          -elsif  @product.category.id.exists?
+            = f.select :category_id, options_for_select(@category_parent_array.map{|c| [c[:name], c[:id], {'data-category'=>c[:id]}]}, @product.category.id), {include_blank: "選択してください"}, { class: "product-information__category--select_form", id: "parent_category"}
+              #children_form.product-information__category--form
+                = f.select :category_id, options_for_select(@category_children.map{|c| [c[:name], c[:id], {'data-category'=>c[:id]}]}), {include_blank: "選択してください"}, { class: "product-information__category--select_form", id: "child_category"}
+          -else
+            = f.select :category_id, options_for_select(@category_parent_array.map{|c| [c[:name], c[:id]]}), {include_blank: "選択してください"}, { class: "product-information__category--select_form", id: "parent_category"}
         -if @product.errors.any? 
           .alert
             %ul

--- a/app/views/products/_new_form.html.haml
+++ b/app/views/products/_new_form.html.haml
@@ -61,21 +61,21 @@
         %label カテゴリー
         %span.require_label 必須
         .product-information__category--form
-          -if @product.category_id.blank?
-            = f.select :category_id, options_for_select(@category_parent_array.map{|c| [c[:name], c[:id], {'data-category'=>c[:id]}]}, ), {include_blank: "選択してください"}, { class: "product-information__category--select_form", id: "parent_category"} 
-          -else
+          -if @product.category_id.present?
             = f.select :category_id, options_for_select(@category_parent_array.map{|c| [c[:name], c[:id], {'data-category'=>c[:id]}]}, @product.category.parent.parent.id), {}, { class: "product-information__category--select_form", id: "parent_category"}
             #children_form.product-information__category--form
               = f.select :category_id, options_for_select(@product.category.parent.parent.children.map{|c| [c[:name], c[:id], {'data-category'=>c[:id]}]}, @product.category.parent.id), {}, { class: "product-information__category--select_form", id: "child_category"}
             #grandchildren_form.product-information__category--form
               = f.select :category_id, options_for_select(@product.category.parent.children.map{|c| [c[:name], c[:id],{'data-category'=>c[:id]}]}, @product.category.id), {}, { class: "product-information__category--select_form", id: "grandchild_category"}
+          -else
+            = f.select :category_id, options_for_select(@category_parent_array.map{|c| [c[:name], c[:id], {'data-category'=>c[:id]}]}, ), {include_blank: "選択してください"}, { class: "product-information__category--select_form", id: "parent_category"} 
         -if @product.errors.any? 
           .alert
             %ul
               -@product.errors.full_messages_for(:category_id).each do |error| 
                 %li= error
       #size_wrapper.product-information__size
-        -if @sizes.present?
+        -if size_exist
           %label.product-information__label サイズ
           %span.require_label 必須
           #size_form.product-information__size--form

--- a/app/views/products/_new_form.html.haml
+++ b/app/views/products/_new_form.html.haml
@@ -61,30 +61,25 @@
         %label カテゴリー
         %span.require_label 必須
         .product-information__category--form
-          -if @product.category.parent.parent.id.exists?
-            = f.select :category_id, options_for_select(@category_parent_array.map{|c| [c[:name], c[:id], {'data-category'=>c[:id]}]}, @product.category.parent.parent.id), {include_blank: "選択してください"}, { class: "product-information__category--select_form", id: "parent_category"}
-              #children_form.product-information__category--form
-                = f.select :category_id, options_for_select(@category_children.map{|c| [c[:name], c[:id], {'data-category'=>c[:id]}]}, @product.category.parent.id), {include_blank: "選択してください"}, { class: "product-information__category--select_form", id: "child_category"}
-              #grandchildren_form.product-information__category--form
-                = f.select :category_id, options_for_select(@category_grandchildren.map{|c| [c[:name], c[:id],{'data-category'=>c[:id]}]}, @product.category.id), {include_blank: "選択してください"}, { class: "product-information__category--select_form", id: "grandchild_category"}
-          -elsif @product.category.parent.id.exists?
-            = f.select :category_id, options_for_select(@category_parent_array.map{|c| [c[:name], c[:id], {'data-category'=>c[:id]}]}, @product.category.parent.id), {include_blank: "選択してください"}, { class: "product-information__category--select_form", id: "parent_category"}
-              #children_form.product-information__category--form
-                = f.select :category_id, options_for_select(@category_children.map{|c| [c[:name], c[:id], {'data-category'=>c[:id]}]}, @product.category.id), {include_blank: "選択してください"}, { class: "product-information__category--select_form", id: "child_category"}
-              #grandchildren_form.product-information__category--form
-                = f.select :category_id, options_for_select(@category_grandchildren.map{|c| [c[:name], c[:id],{'data-category'=>c[:id]}]}), {include_blank: "選択してください"}, { class: "product-information__category--select_form", id: "grandchild_category"}
-          -elsif  @product.category.id.exists?
-            = f.select :category_id, options_for_select(@category_parent_array.map{|c| [c[:name], c[:id], {'data-category'=>c[:id]}]}, @product.category.id), {include_blank: "選択してください"}, { class: "product-information__category--select_form", id: "parent_category"}
-              #children_form.product-information__category--form
-                = f.select :category_id, options_for_select(@category_children.map{|c| [c[:name], c[:id], {'data-category'=>c[:id]}]}), {include_blank: "選択してください"}, { class: "product-information__category--select_form", id: "child_category"}
+          -if @product.category_id.blank?
+            = f.select :category_id, options_for_select(@category_parent_array.map{|c| [c[:name], c[:id], {'data-category'=>c[:id]}]}, ), {include_blank: "選択してください"}, { class: "product-information__category--select_form", id: "parent_category"} 
           -else
-            = f.select :category_id, options_for_select(@category_parent_array.map{|c| [c[:name], c[:id]]}), {include_blank: "選択してください"}, { class: "product-information__category--select_form", id: "parent_category"}
+            = f.select :category_id, options_for_select(@category_parent_array.map{|c| [c[:name], c[:id], {'data-category'=>c[:id]}]}, @product.category.parent.parent.id), {}, { class: "product-information__category--select_form", id: "parent_category"}
+            #children_form.product-information__category--form
+              = f.select :category_id, options_for_select(@product.category.parent.parent.children.map{|c| [c[:name], c[:id], {'data-category'=>c[:id]}]}, @product.category.parent.id), {}, { class: "product-information__category--select_form", id: "child_category"}
+            #grandchildren_form.product-information__category--form
+              = f.select :category_id, options_for_select(@product.category.parent.children.map{|c| [c[:name], c[:id],{'data-category'=>c[:id]}]}, @product.category.id), {}, { class: "product-information__category--select_form", id: "grandchild_category"}
         -if @product.errors.any? 
           .alert
             %ul
               -@product.errors.full_messages_for(:category_id).each do |error| 
                 %li= error
       #size_wrapper.product-information__size
+        -if @sizes.present?
+          %label.product-information__label サイズ
+          %span.require_label 必須
+          #size_form.product-information__size--form
+            = f.collection_select :size_id, @sizes, :id, :size, {include_blank: "選択してください"}, { class: "product-information__size--select_form", id: "size"}
         -if @product.errors.any? 
           .alert
             %ul

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -7,6 +7,7 @@ require 'carrierwave/storage/fog'
 CarrierWave.configure do |config|
   if Rails.env.production? #本番環境：AWS使用
     config.storage = :fog
+    # config.cache_storage = :fog
     config.fog_provider = 'fog/aws'
     config.fog_credentials = {
       provider: 'AWS',


### PR DESCRIPTION
# What
バリデーションエラー時入力フォームに戻った際、画像とカテゴリー、サイズ欄が初期の入力されていない状態に戻ってしまうため、入力した情報を保持するよう修正した。
画像にはcacheを用い画像を保持するように実装した。
カテゴリー及びサイズ欄はカテゴリーやサイズが入力されていた場合に親、子、孫、サイズのselectフォームを表示するよう条件分岐し実装を行った。

# Why
ユーザービリティの向上のためバリデーションエラー後も入力していた項目はそのまま入力した状態にしたかったため。

![バリデーションエラー時の挙動](https://user-images.githubusercontent.com/63962501/90029016-4fac1f80-dcf5-11ea-9eb5-854ff3767a85.gif)
