### PR TITLE
background-imageの記述を本番環境にも適応するよう変更

### DIFF
--- a/app/assets/stylesheets/modules/_search_header_products.scss
+++ b/app/assets/stylesheets/modules/_search_header_products.scss
@@ -55,7 +55,7 @@
     display: inline-block;
     width: 20px;
     height: 20px;
-    background-image: url(icon-search.png);
+    background-image: image-url('icon-search.png');
     background-size: contain;
     vertical-align: middle;
   }


### PR DESCRIPTION
# What
ローカルで表示されているのに本番環境では表示されない現象を修正した。
background-image: url
を
background-image: image-url
に変更している。
ローカルでは虫眼鏡のアイコンが問題なく表示された。
#Why
本番環境でもローカルと同様に画像を表示させたかったため

<img width="942" alt="ローカル" src="https://user-images.githubusercontent.com/63962501/90242631-59a25f80-de68-11ea-8904-87ede4e7c416.png">
