### PR TITLE
マイページの「メール/パスワード」のマークアップ

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,6 +27,7 @@
 @import "user_my_page_modules/sold_products";
 @import "user_my_page_modules/purchased_products";
 @import "user_my_page_modules/logout_link";
+@import "user_my_page_modules/edit_my_page";
 
 @import "font-awesome-sprockets";
 @import "font-awesome";

--- a/app/assets/stylesheets/user_my_page_modules/edit_my_page.scss
+++ b/app/assets/stylesheets/user_my_page_modules/edit_my_page.scss
@@ -1,0 +1,106 @@
+.edit_user_contents {
+  max-width: 700px;
+  margin: 0 auto;
+  background-color: #fff;
+  h2 {
+    padding: 12px 4%;
+    border-bottom: 1px solid #f5f5f5;
+    text-align: center;
+    font-size: 18px;
+    line-height: 1.4;
+    margin: 0;
+  }
+  .edit_user {
+    padding: 40px;
+    //border-top: 1px solid #f5f5f5;
+  }
+  .innner_content {
+    max-width: 320px;
+    margin: 0 auto;
+    padding: 0;
+    .upper_field {
+      margin:0 0 0;
+      label {
+        font-weight: 600;
+      }
+      #user_email {
+        width: 100%;
+        margin: 8px 0 0;
+        height: 48px;
+        padding: 10px 16px 8px;
+        border-radius: 4px;
+        border: solid 1px #ccc;
+        background: #fff;
+        line-height: 1.5;
+        font-size: 16px;
+      }
+      p {
+        margin: 8px 0 0;
+        line-height: 1.5;
+        color: #888;
+        font-size: 12px;
+      }
+    }
+    .field {
+      margin: 40px 0 0; 
+      label {
+        font-weight: 600;
+      }
+      #user_password {
+        width: 100%;
+        margin: 8px 0 0;
+        height: 48px;
+        padding: 10px 16px 8px;
+        border-radius: 4px;
+        border: solid 1px #ccc;
+        background: #fff;
+        line-height: 1.5;
+        font-size: 16px;
+      }
+      p {
+        margin: 8px 0 0;
+        line-height: 1.5;
+        color: #888;
+        font-size: 12px;
+      }
+      #user_password_confirmation {
+        width: 100%;
+        margin: 8px 0 0;
+        height: 48px;
+        padding: 10px 16px 8px;
+        border-radius: 4px;
+        border: solid 1px #ccc;
+        background: #fff;
+        line-height: 1.5;
+        font-size: 16px;
+      }
+      #user_current_password {
+        width: 100%;
+        margin: 8px 0 0;
+        height: 48px;
+        padding: 10px 16px 8px;
+        border-radius: 4px;
+        border: solid 1px #ccc;
+        background: #fff;
+        line-height: 1.5;
+        font-size: 16px;
+      }   
+         
+    }
+    .actions {
+      margin: 40px 0 0;
+        input {
+        background: #3ccace;
+        border: 1px solid #3ccace;
+        height: 48px;
+        color: #fff;
+        display: block;
+        width: 100%;
+        font-size: 14px;
+        border-radius: 4px;
+        cursor: pointer;
+        text-align: center;
+      }
+    }
+  }
+}

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -31,7 +31,3 @@
         = f.password_field :current_password, autocomplete: "current-password"
       .actions
         = f.submit "変更する"
-//%h3 Cancel my account
-//%p
-//Unhappy? #{button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete}
-//= link_to "Back", :back

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,36 +1,37 @@
-%h2
-  Edit #{resource_name.to_s.humanize}
-= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
-  = render "devise/shared/error_messages", resource: resource
-  .field
-    = f.label :email
-    %br/
-    = f.email_field :email, autofocus: true, autocomplete: "email"
-  - if devise_mapping.confirmable? && resource.pending_reconfirmation?
-    %div
-      Currently waiting confirmation for: #{resource.unconfirmed_email}
-  .field
-    = f.label :password
-    %i (leave blank if you don't want to change it)
-    %br/
-    = f.password_field :password, autocomplete: "new-password"
-    - if @minimum_password_length
-      %br/
-      %em
-        = @minimum_password_length
-        characters minimum
-  .field
-    = f.label :password_confirmation
-    %br/
-    = f.password_field :password_confirmation, autocomplete: "new-password"
-  .field
-    = f.label :current_password
-    %i (we need your current password to confirm your changes)
-    %br/
-    = f.password_field :current_password, autocomplete: "current-password"
-  .actions
-    = f.submit "Update"
-%h3 Cancel my account
-%p
-  Unhappy? #{button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete}
-= link_to "Back", :back
+%section.edit_user_contents
+  %h2
+    メール/パスワード
+  = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
+    = render "devise/shared/error_messages", resource: resource
+    .innner_content
+      .upper_field
+        = f.label :email
+        %br/
+        = f.email_field :email, autofocus: true, autocomplete: "email"
+        %p メールアドレスを変更すると確認メールが送信されます。メール内のURLをクリックすると変更完了です。
+      - if devise_mapping.confirmable? && resource.pending_reconfirmation?
+        %div
+          Currently waiting confirmation for: #{resource.unconfirmed_email}
+      .field
+        = f.label :password
+        //%i (leave blank if you don't want to change it)
+        %br/
+        = f.password_field :password, autocomplete: "new-password",placeholder:"7文字以上の半角英数字"
+       
+        %br
+        %p ※英字と数字の両方を含めて設定してください
+      .field
+        = f.label :password_confirmation
+        %br/
+        = f.password_field :password_confirmation, autocomplete: "new-password"
+      .field
+        = f.label :current_password
+        //%i (we need your current password to confirm your changes)
+        %br/
+        = f.password_field :current_password, autocomplete: "current-password"
+      .actions
+        = f.submit "変更する"
+//%h3 Cancel my account
+//%p
+//Unhappy? #{button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete}
+//= link_to "Back", :back


### PR DESCRIPTION
# what
マイページの「メール/パスワード」のマークアップの実装
# Why
メンバー内で決めた項目だったのでマークアップでビューを整える必要があったため
### スクショ
https://gyazo.com/64eaa7f2d73e4c602019d2c854b58abe