### PR TITLE
【サーバサイド】商品出品・編集、画像投稿機能　画像消去後に投稿すると上手く反映されないエラー修正

### DIFF
--- a/app/assets/javascripts/products.js
+++ b/app/assets/javascripts/products.js
@@ -65,12 +65,13 @@ $(function() {
   //
 
   // file_fieldのnameに動的なindexをつける為の配列
-  let fileIndex = [1,2,3,4];
+  let fileIndex = [1,2,3,4,5];
   // 既に使われているindexを除外
   lastIndex = $('.js-file_group:last').data('index');
   fileIndex.splice(0, lastIndex);
-  // $('.hidden-destroy').hide();
+  $('.hidden-destroy').hide();
  
+  //画像投稿
   $('#image-box').on('change', '.js-file', function(e) {
     // js-fileのidの数値のみ取得
     var id = $(this).attr('id').replace(/[^0-9]/g, '');
@@ -100,56 +101,7 @@ $(function() {
       // ラベルのオプションを更新する
       $('.image_input_btn').attr({id: `image_input_btn--${fileIndex[0]-1}`, for:`product_images_attributes_${fileIndex[0]-1}_src`});
     }
-    // if (count < 5) {
-    //   //プレビューの数でラベルのオプションを更新する 
-    //   $('.image_input_btn').attr({id: `image_input_btn--${count}`, for:`product_images_attributes_${count}_src`});
-    // }
   });
-
-  // // プレビューの追加
-  // $('#image-box').on('change', '.js-file', function() {
-  //   setLabel();
-  //   // js-fileのidの数値のみ取得
-  //   var id = $(this).attr('id').replace(/[^0-9]/g, '');
-  //   // image_input_btnのidとforを更新
-  //   $('.image_input_btn').attr({id: `image_input_btn--${id}`, for: `product_images_attributes_${id}_src`});
-  //   // 選択したfileのオブジェクトを取得
-  //   var file = this.files[0];
-  //   var reader = new FileReader();
-  //   //readAsDataURLで指定したFileオブジェクトを読み込む
-  //   reader.readAsDataURL(file);
-  //   //読み込み時に発火するイベント
-  //   reader.onload = function() {
-  //     var image = this.result;
-  //     //プレビューがもともと無かった場合はhtmlを追加
-  //     if ($(`#preview_image_box__${id}`).length == 0) {
-  //       var count = $('.preview_image_box').length;
-  //       var html = buildHTML(id);
-  //       //ラベルの直前のプレビュー群にプレビューを追加
-  //       var prevContent = $('.image_input_btn').prev();
-  //       $(prevContent).append(html);
-  //     }
-  //     //イメージを追加
-  //     $(`#preview_image_box__${id} img`).attr('src', `${image}`);
-  //     var count = $('.preview_image_box').length;
-  //     //プレビューが5こあったらラベルを隠す
-  //     if (count == 5) {
-  //       $('.image_input_btn').hide();
-  //     }
-  //     //プレビューを削除したフィールドにdestroy用のチェックボックスがあった場合、チェックを外す
-  //     if ($(`#product_images_attributes_${id}__destroy`)) {
-  //       $(`#product_images_attributes_${id}__destroy`).prop('checked', false);
-  //     }
-  //     //image_input_btnのwidth操作
-  //     setLabel();
-  //     //image_input_btnのidとforの値を変更
-      
-  //     if (count < 5) {
-  //       //プレビューの数でラベルのオプションを更新する 
-  //       $('.image_input_btn').attr({id: `image_input_btn--${count}`, for:`product_images_attributes_${count}_src`});
-  //     }
-  //   }
-  // });
 
   //画像の削除
   $('#image-box').on('click', '.js-remove', function() {

--- a/app/assets/javascripts/products.js
+++ b/app/assets/javascripts/products.js
@@ -65,7 +65,7 @@ $(function() {
   //
 
   // file_fieldのnameに動的なindexをつける為の配列
-  let fileIndex = [1,2,3,4,5];
+  let fileIndex = [1,2,3,4,5,6,7,8,9,10];
   // 既に使われているindexを除外
   lastIndex = $('.js-file_group:last').data('index');
   fileIndex.splice(0, lastIndex);

--- a/app/assets/javascripts/products.js
+++ b/app/assets/javascripts/products.js
@@ -1,12 +1,12 @@
 $(function() { 
-  //プレビューのthmlを定義
-  function buildHTML(count) {
-    var html = `<div class="preview_image_box" id="preview_image_box__${count}">
+  //プレビュー用のhtmlを定義
+  function buildHTML(index, url) {
+    var html = `<div class="preview_image_box" id="preview_image_box__${index}">
                   <div class="upper-box">
-                    <img src="" alt="preview" width="120px" height="120px" class=""preview_image>
+                    <img data-index="${index}" src="${url}" alt="preview" width="120px" height="120px" class=""preview_image>
                   </div>
                   <div class="update_box">
-                    <div class="js-remove" id="delete_btn_${count}">
+                    <div class="js-remove" id="delete_btn_${index}">
                       <span>削除</span>
                     </div>
                   </div>
@@ -14,8 +14,27 @@ $(function() {
     return html;
   }
 
+  // 画像用のinputを生成
+  const buildFileField = (num)=> {
+    const html = `<div data-index="${num}" class="js-file_group">
+                    <input class="js-file" type="file"
+                    name="product[images_attributes][${num}][src]"
+                    id="product_images_attributes_${num}_src"><br>
+                  </div>`;
+    return html;
+  }
+
+  // image_input_btnのwidth操作
+  function setLabel() {
+    // プレビューボックスのwidthを取得し、maxから引くことでimage_input_btnのwidthを決定
+    var prevContent = $('.image_input_btn').prev();
+    labelWidth = (640 - $(prevContent).css('width').replace(/[^0-9]/g, ''));
+    $('.image_input_btn').css('width', labelWidth);
+  }
+  //
+
   //投稿編集時
-  //products/:i/editページへリンクした際のアクション
+  //products/:i/editページへリンクした際のwidth操作
   if (window.location.href.match(/\/products\/\d+\/edit/)) {
     //投稿済み画像のプレビュー表示欄の要素を取得する
     var prevContent = $('.image_input_btn').prev();
@@ -30,7 +49,7 @@ $(function() {
   }
   //
 
-  //バリデーションエラーで入力欄に戻った時
+  //バリデーションエラーで入力欄に戻った時のwidth操作
   if (window.location.href.match(/\/(products)$/)) {
     //投稿済み画像のプレビュー表示欄の要素を取得する
     var prevContent = $('.image_input_btn').prev();
@@ -45,59 +64,92 @@ $(function() {
   }
   //
 
-  // image_input_btnのwidth操作
-  function setLabel() {
-    // プレビューボックスのwidthを取得し、maxから引くことでimage_input_btnのwidthを決定
-    var prevContent = $('.image_input_btn').prev();
-    labelWidth = (640 - $(prevContent).css('width').replace(/[^0-9]/g, ''));
-    $('.image_input_btn').css('width', labelWidth);
-  }
-  //
-
-  // プレビューの追加
-  $('#image-box').on('change', '.hidden-field', function() {
-    setLabel();
-    // hidden-fieldのidの数値のみ取得
+  // file_fieldのnameに動的なindexをつける為の配列
+  let fileIndex = [1,2,3,4];
+  // 既に使われているindexを除外
+  lastIndex = $('.js-file_group:last').data('index');
+  fileIndex.splice(0, lastIndex);
+  // $('.hidden-destroy').hide();
+ 
+  $('#image-box').on('change', '.js-file', function(e) {
+    // js-fileのidの数値のみ取得
     var id = $(this).attr('id').replace(/[^0-9]/g, '');
     // image_input_btnのidとforを更新
     $('.image_input_btn').attr({id: `image_input_btn--${id}`, for: `product_images_attributes_${id}_src`});
-    // 選択したfileのオブジェクトを取得
-    var file = this.files[0];
-    var reader = new FileReader();
-    //readAsDataURLで指定したFileオブジェクトを読み込む
-    reader.readAsDataURL(file);
-    //読み込み時に発火するイベント
-    reader.onload = function() {
-      var image = this.result;
-      //プレビューがもともと無かった場合はhtmlを追加
-      if ($(`#preview_image_box__${id}`).length == 0) {
-        var count = $('.preview_image_box').length;
-        var html = buildHTML(id);
-        //ラベルの直前のプレビュー群にプレビューを追加
-        var prevContent = $('.image_input_btn').prev();
-        $(prevContent).append(html);
-      }
-      //イメージを追加
-      $(`#preview_image_box__${id} img`).attr('src', `${image}`);
-      var count = $('.preview_image_box').length;
+    // ファイルのブラウザ上でのURLを取得する
+    const file = e.target.files[0];
+    const blobUrl = window.URL.createObjectURL(file);
+    // 該当indexを持つimgがあれば取得して変数imgに入れる(画像変更の処理)
+    if (img = $(`img[data-index="${id}"]`)[0]) {
+      img.setAttribute('src', blobUrl);
+    } else {  // プレビュー追加の処理
+      setLabel();
+      $('#previews').append(buildHTML(id, blobUrl));
+      // fileIndexの先頭の数字を使ってinputを作る
+      $('.hidden_post_form').append(buildFileField(fileIndex[0]));
+      fileIndex.shift();
+      // 末尾の数に1足した数を追加する
+      fileIndex.push(fileIndex[fileIndex.length - 1] + 1)
+      //image_input_btnのwidth操作
+      var count = $('.preview_image_box').length; 
+       setLabel();
       //プレビューが5こあったらラベルを隠す
       if (count == 5) {
         $('.image_input_btn').hide();
       }
-      //プレビューを削除したフィールドにdestroy用のチェックボックスがあった場合、チェックを外す
-      if ($(`#product_images_attributes_${id}__destroy`)) {
-        $(`#product_images_attributes_${id}__destroy`).prop('checked', false);
-      }
-      //image_input_btnのwidth操作
-      setLabel();
-      //image_input_btnのidとforの値を変更
-      
-      if (count < 5) {
-        //プレビューの数でラベルのオプションを更新する 
-        $('.image_input_btn').attr({id: `image_input_btn--${count}`, for:`product_images_attributes_${count}_src`});
-      }
+      // ラベルのオプションを更新する
+      $('.image_input_btn').attr({id: `image_input_btn--${fileIndex[0]-1}`, for:`product_images_attributes_${fileIndex[0]-1}_src`});
     }
+    // if (count < 5) {
+    //   //プレビューの数でラベルのオプションを更新する 
+    //   $('.image_input_btn').attr({id: `image_input_btn--${count}`, for:`product_images_attributes_${count}_src`});
+    // }
   });
+
+  // // プレビューの追加
+  // $('#image-box').on('change', '.js-file', function() {
+  //   setLabel();
+  //   // js-fileのidの数値のみ取得
+  //   var id = $(this).attr('id').replace(/[^0-9]/g, '');
+  //   // image_input_btnのidとforを更新
+  //   $('.image_input_btn').attr({id: `image_input_btn--${id}`, for: `product_images_attributes_${id}_src`});
+  //   // 選択したfileのオブジェクトを取得
+  //   var file = this.files[0];
+  //   var reader = new FileReader();
+  //   //readAsDataURLで指定したFileオブジェクトを読み込む
+  //   reader.readAsDataURL(file);
+  //   //読み込み時に発火するイベント
+  //   reader.onload = function() {
+  //     var image = this.result;
+  //     //プレビューがもともと無かった場合はhtmlを追加
+  //     if ($(`#preview_image_box__${id}`).length == 0) {
+  //       var count = $('.preview_image_box').length;
+  //       var html = buildHTML(id);
+  //       //ラベルの直前のプレビュー群にプレビューを追加
+  //       var prevContent = $('.image_input_btn').prev();
+  //       $(prevContent).append(html);
+  //     }
+  //     //イメージを追加
+  //     $(`#preview_image_box__${id} img`).attr('src', `${image}`);
+  //     var count = $('.preview_image_box').length;
+  //     //プレビューが5こあったらラベルを隠す
+  //     if (count == 5) {
+  //       $('.image_input_btn').hide();
+  //     }
+  //     //プレビューを削除したフィールドにdestroy用のチェックボックスがあった場合、チェックを外す
+  //     if ($(`#product_images_attributes_${id}__destroy`)) {
+  //       $(`#product_images_attributes_${id}__destroy`).prop('checked', false);
+  //     }
+  //     //image_input_btnのwidth操作
+  //     setLabel();
+  //     //image_input_btnのidとforの値を変更
+      
+  //     if (count < 5) {
+  //       //プレビューの数でラベルのオプションを更新する 
+  //       $('.image_input_btn').attr({id: `image_input_btn--${count}`, for:`product_images_attributes_${count}_src`});
+  //     }
+  //   }
+  // });
 
   //画像の削除
   $('#image-box').on('click', '.js-remove', function() {
@@ -107,9 +159,11 @@ $(function() {
     var id = $(this).attr('id').replace(/[^0-9]/g, '');
     // 取得したidの該当するプレビューを削除
     $(`#preview_image_box__${id}`).remove();
-    // フォームの中身を削除
-    $(`#product_images_attributes_${id}_src`).val("");
+    // フォームを削除
     $(`#product_images_attributes_${id}__destroy`).prop('checked',true);
+    $(`#product_images_attributes_${id}_src`).parent().remove();
+    // 画像入力欄が0個にならないようにしておく
+    if ($('.js-file').length == 0) $('.hidden_post_form').append(buildFileField(fileIndex[0]));
     // 削除時のラベル操作
     var count = $('.preview_image_box').length;
     // 5個目が消されたらラベルを表示
@@ -118,9 +172,5 @@ $(function() {
     }
     //image_input_btnのwidth操作
     setLabel();
-    if(id < 5) {
-      // 削除された際に、空っぽになったfile_fieldをもう一度入力可能にする。
-      $('.image_input_btn').attr({id: `image_input_btn--${id}`, for: `product_images_attributes_${id}_src`});
-    }
   });
 });

--- a/app/assets/stylesheets/modules/_edit_products.scss
+++ b/app/assets/stylesheets/modules/_edit_products.scss
@@ -141,10 +141,7 @@
           }
         }
         .hidden_post_form {
-          .hidden-field {
-            display: none;
-          } 
-          .hidden-checkbox {
+          .js-file {
             display: none;
           }
         }

--- a/app/assets/stylesheets/modules/_new_products.scss
+++ b/app/assets/stylesheets/modules/_new_products.scss
@@ -136,7 +136,7 @@
         }
         .hidden_post_form {
           .js-file {
-            // display: none;
+            display: none;
           } 
         }
         .alert {

--- a/app/assets/stylesheets/modules/_new_products.scss
+++ b/app/assets/stylesheets/modules/_new_products.scss
@@ -135,8 +135,8 @@
           }
         }
         .hidden_post_form {
-          .hidden-field {
-            display: none;
+          .js-file {
+            // display: none;
           } 
         }
         .alert {

--- a/app/views/products/_edit_form.html.haml
+++ b/app/views/products/_edit_form.html.haml
@@ -25,11 +25,11 @@
               =image_tag('icon_camera.png', class: "image_input_btn_camera")
               .image_input_btn_text クリックしてファイルをアップロード
           .hidden_post_form
-            = f.fields_for :images do |i|
+            = f.fields_for :images do |image|
               -# プレビューが出ている分のfile_fieldとdelete用のチェックボックスを設置
-              = i.file_field :src, class: "hidden-field"
-              = i.check_box :_destroy, class: "hidden-checkbox"
-              = i.hidden_field :src_cache
+              = image.file_field :src, class: "hidden-field"
+              = image.check_box :_destroy,data:{ index: image.index } class: "hidden-checkbox"
+              = image.hidden_field :src_cache
             -@product.images.length.upto(4) do |i|
               %input{class: "hidden-field", type: "file", name: "product[images_attributes][#{i}][src]", id: "product_images_attributes_#{i}_src"}
         -if @product.errors.any? 

--- a/app/views/products/_edit_form.html.haml
+++ b/app/views/products/_edit_form.html.haml
@@ -20,18 +20,20 @@
                     %span 削除
         -if @product.persisted?
           -# プレビューの数に合わせてforオプションを指定
-          %label{for: "product_images_attributes_#{@product.images.length}_src", class: "image_input_btn", id: "image_input_btn--#{@product.images.length}"} 
+          %label{for: "product_images_attributes_#{@product.images.count}_src", class: "image_input_btn", id: "image_input_btn--#{@product.images.count}"} 
             #posts.post_form
               =image_tag('icon_camera.png', class: "image_input_btn_camera")
               .image_input_btn_text クリックしてファイルをアップロード
           .hidden_post_form
             = f.fields_for :images do |image|
               -# プレビューが出ている分のfile_fieldとdelete用のチェックボックスを設置
-              = image.file_field :src, class: "hidden-field"
-              = image.check_box :_destroy,data:{ index: image.index } class: "hidden-checkbox"
-              = image.hidden_field :src_cache
-            -@product.images.length.upto(4) do |i|
-              %input{class: "hidden-field", type: "file", name: "product[images_attributes][#{i}][src]", id: "product_images_attributes_#{i}_src"}
+              %div{ data: {index: "#{ image.index }" }, class: "js-file_group" }
+                = image.file_field :src, class: "js-file"
+                = image.check_box :_destroy, data:{ index: image.index }, class: "hidden-destroy"
+                = image.hidden_field :src_cache
+            -# 投稿用のfile_fieldを設置
+            %div{ data: {index: "#{ @product.images.count }" }, class: "js-file_group" }
+              = file_field_tag :src, name: "product[images_attributes][#{@product.images.count}][src]", id:"product_images_attributes_#{@product.images.count}_src", class: 'js-file'
         -if @product.errors.any? 
           .alert
             %ul

--- a/app/views/products/_new_form.html.haml
+++ b/app/views/products/_new_form.html.haml
@@ -7,7 +7,7 @@
       %p.post-image-list__explanation 最大5枚までアップロードできます
       #image-box.post-image-list__box
         #previews.preview_list
-          -# cacheに値がセットされている場合は画像を表示
+          -# バリデーションエラー時cacheに値がセットされている場合は画像を表示
           -if @product.images[0].src.url.present?
             -@product.images.each_with_index do |image, i|
               .preview_image_box{id: "preview_image_box__#{i}"}
@@ -16,22 +16,17 @@
                 .update_box
                   .js-remove{id: "delete_btn_#{i}"}
                     %span 削除
-              -# =image_tag @product.images[0].src.url if @product.images[0].src.url.present?
         %label{for: "product_images_attributes_0_src", class: "image_input_btn", id: "image_input_btn--0"} 
           #posts.post_form
             =image_tag('icon_camera.png', class: "image_input_btn_camera")
             .image_input_btn_text クリックしてファイルをアップロード
         .hidden_post_form
-          =f.fields_for :images do |image|
-            
+          =f.fields_for :images do |image|          
             -# 画像がビルドされた際に振られるidを取得
-            =image.file_field :src, class:"hidden-field" 
-            =image.file_field :src, class:"hidden-field", name: "product[images_attributes][1][src]", id: "product_images_attributes_1_src"
-            =image.file_field :src, class:"hidden-field", name: "product[images_attributes][2][src]", id: "product_images_attributes_2_src"
-            =image.file_field :src, class:"hidden-field", name: "product[images_attributes][3][src]", id: "product_images_attributes_3_src"
-            =image.file_field :src, class:"hidden-field", name: "product[images_attributes][4][src]", id: "product_images_attributes_4_src"
-            -# cacheを使用するためにhidden_fieldを設置
-            =image.hidden_field :src_cache
+            %div{ data: {index: "#{image.index}" }, class: "js-file_group" }
+              =image.file_field :src, class:"js-file" 
+              -# cacheを使用するためにhidden_fieldを設置
+              =image.hidden_field :src_cache
         -if @product.errors.any? 
           .alert
             %ul


### PR DESCRIPTION
##  What
商品出品・編集時、画像を消去してから複数枚画像を投稿すると、最初に投稿した画像が上書きされてしまうエラーが見つかったため修正した。
修正前まではinputタグを最初から5つ設置し、プレビュー画像の枚数によりどのinputタグを選択するかという実装をしていたが、それでは画像を消去した後ずっと同じinputタグを選択してしまうという現象が起こっていた。
そのためinputタグを最初から設置するのではなく、画像を登録したらinputタグを1つずつ増やし、消去時はプレビュー画像もinputタグも消去する形式に変更した。

## Why
画像を消去した後、画像を登録できなくなってしまうエラーを解消するため。

商品出品　画像登録
![商品出品画像登録](https://user-images.githubusercontent.com/63962501/90337705-2fdf6900-e01f-11ea-8473-dc7466be633a.gif)

商品出品　画像消去から登録
![商品出品画像消去から登録](https://user-images.githubusercontent.com/63962501/90337715-408fdf00-e01f-11ea-95c4-336659410ad7.gif)

商品編集　画像消去から登録
![商品編集画像消去から登録](https://user-images.githubusercontent.com/63962501/90337951-0a535f00-e021-11ea-89be-5b8c43564365.gif)